### PR TITLE
Add support for super.users

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The plugin supports the following properties:
 | `opa.authorizer.cache.initial.capacity` | `5000` | `5000` | Initial decision cache size. |
 | `opa.authorizer.cache.maximum.size` | `50000` | `50000` | Max decision cache size. |
 | `opa.authorizer.cache.expire.after.seconds` | `3600` | `3600` | Decision cache expiry in seconds. |
+| `super.users` | `User:alice;User:bob` | `` | Super users which are always allowed. |
 
 ## Usage
 


### PR DESCRIPTION
This PR adds support for `super.users`. When the `super.users` option is configured and the KafkaPrincipal is on the super users list, it will be always allowed without checking with OPA. This is useful for example when you want to configure the Kafka brokers or some other system components as always allowed without that being handled in the OPA policies.

I used intentionally the `super.users` option without the `opa.authorizer.` prefix to keep this compatible with the SimpleAclAuthorizer and any other authorizers implementing the same feature.

I'm not exactly Scala developer ... so I hope that the code is ok (feature wise I tested it in actual Kafka). Please let me know if there is some way to do it _better_.