### PR TITLE
Update cache to caffeine

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     compileOnly group: 'org.apache.kafka', name: 'kafka_2.13', version: '4.0.0'
     compileOnly group: 'com.typesafe.scala-logging', name: 'scala-logging_2.13', version: '3.9.5'
     implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-scala_2.13', version: '2.16.2'
-    implementation group: 'com.google.guava', name: 'guava', version: '32.1.3-jre'
+    implementation group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '3.2.0'
 
     testImplementation group: 'org.scalatest', name: 'scalatest_2.13', version: '3.2.17'
     testImplementation group: 'org.scalatestplus', name: 'junit-4-13_2.13', version: '3.2.17.0'
@@ -40,7 +40,7 @@ dependencies {
 shadowJar {
     dependencies {
         exclude(dependency {
-            !(it.moduleGroup in ['org.openpolicyagent.kafka', 'com.google.guava']
+            !(it.moduleGroup in ['org.openpolicyagent.kafka', 'com.github.ben-manes.caffeine']
                     || (it.moduleGroup == 'com.fasterxml.jackson.module' && it.moduleName == 'jackson-module-scala_2.13')
                     || (it.moduleGroup == 'com.thoughtworks.paranamer' && it.moduleName == 'paranamer'))
         })

--- a/src/test/scala/org/openpolicyagent/kafka/OpaAuthorizerSpec.scala
+++ b/src/test/scala/org/openpolicyagent/kafka/OpaAuthorizerSpec.scala
@@ -79,7 +79,7 @@ class OpaAuthorizerSpec extends AnyFlatSpec with Matchers with PrivateMethodTest
     val request = createRequest("alice-producer", actions)
 
     opaAuthorizer.authorize(request.requestContext, request.actions.asJava) should be (List(AuthorizationResult.ALLOWED).asJava)
-    opaAuthorizer.getCache.size should be (1)
+    opaAuthorizer.getCache.estimatedSize() should be (1)
   }
 
   "OpaAuthorizer" should "return authorization results for multiple actions in the same request in right order" in {
@@ -103,7 +103,7 @@ class OpaAuthorizerSpec extends AnyFlatSpec with Matchers with PrivateMethodTest
       AuthorizationResult.ALLOWED,
       AuthorizationResult.ALLOWED,
       AuthorizationResult.ALLOWED).asJava)
-    opaAuthorizer.getCache.size should be (4)
+    opaAuthorizer.getCache.estimatedSize() should be (4)
   }
 
   "OpaAuthorizer" should "not authorize when username does not match name of topic" in {
@@ -114,7 +114,7 @@ class OpaAuthorizerSpec extends AnyFlatSpec with Matchers with PrivateMethodTest
     val request = createRequest("alice-producer", actions)
 
     opaAuthorizer.authorize(request.requestContext, request.actions.asJava) should be (List(AuthorizationResult.DENIED).asJava)
-    opaAuthorizer.getCache.size should be (1)
+    opaAuthorizer.getCache.estimatedSize() should be (1)
   }
 
   "OpaAuthorizer" should "not authorize read request for producer" in {
@@ -125,7 +125,7 @@ class OpaAuthorizerSpec extends AnyFlatSpec with Matchers with PrivateMethodTest
     val request = createRequest("alice-producer", actions)
 
     opaAuthorizer.authorize(request.requestContext, request.actions.asJava) should be (List(AuthorizationResult.DENIED).asJava)
-    opaAuthorizer.getCache.size should be (1)
+    opaAuthorizer.getCache.estimatedSize() should be (1)
   }
 
   "OpaAuthorizer" should "not authorize write request for consumer" in {
@@ -136,7 +136,7 @@ class OpaAuthorizerSpec extends AnyFlatSpec with Matchers with PrivateMethodTest
     val request = createRequest("alice-consumer", actions)
 
     opaAuthorizer.authorize(request.requestContext, request.actions.asJava) should be (List(AuthorizationResult.DENIED).asJava)
-    opaAuthorizer.getCache.size should be (1)
+    opaAuthorizer.getCache.estimatedSize() should be (1)
   }
 
   "OpaAuthorizer" should "cache the first request" in {
@@ -150,7 +150,7 @@ class OpaAuthorizerSpec extends AnyFlatSpec with Matchers with PrivateMethodTest
       opaAuthorizer.authorize(request.requestContext, request.actions.asJava) should be (List(AuthorizationResult.ALLOWED).asJava)
     }
 
-    opaAuthorizer.getCache.size should be (1)
+    opaAuthorizer.getCache.estimatedSize() should be (1)
 
     val otherActions = List(
       createAction("bob-topic", AclOperation.READ),
@@ -161,7 +161,7 @@ class OpaAuthorizerSpec extends AnyFlatSpec with Matchers with PrivateMethodTest
       opaAuthorizer.authorize(otherRequest.requestContext, otherRequest.actions.asJava) should be (List(AuthorizationResult.ALLOWED).asJava)
     }
 
-    opaAuthorizer.getCache.size should be (2)
+    opaAuthorizer.getCache.estimatedSize() should be (2)
   }
 
   "OpaAuthorizer" should "not cache decisions while errors occur" in {
@@ -172,7 +172,7 @@ class OpaAuthorizerSpec extends AnyFlatSpec with Matchers with PrivateMethodTest
     val request = createRequest("alice-consumer", actions)
 
     opaAuthorizer.authorize(request.requestContext, request.actions.asJava) should be (List(AuthorizationResult.DENIED).asJava)
-    opaAuthorizer.getCache.size should be (0)
+    opaAuthorizer.getCache.estimatedSize() should be (0)
   }
 
   "OpaAuthorizer" should "authorize super users without checking with OPA" in {
@@ -206,7 +206,7 @@ class OpaAuthorizerSpec extends AnyFlatSpec with Matchers with PrivateMethodTest
       new ListenerName("SASL_PLAINTEXT"), SecurityProtocol.SASL_PLAINTEXT, new ClientInformation("rdkafka", "1.0.0"), false)
 
     opaAuthorizer.authorize(requestContext, actions.asJava) should be (List(AuthorizationResult.ALLOWED).asJava)
-    opaAuthorizer.getCache.size should be (1)
+    opaAuthorizer.getCache.estimatedSize() should be (1)
   }
 
   "OpaAuthorizer" should "set up metrics system if enabled" in {
@@ -287,7 +287,7 @@ class OpaAuthorizerSpec extends AnyFlatSpec with Matchers with PrivateMethodTest
     val cacheUsagePercentageActual = server.getAttribute(
       new ObjectName(MetricsLabel.NAMESPACE + ":type=" + MetricsLabel.REQUEST_HANDLE_GROUP),
       MetricsLabel.CACHE_USAGE_PERCENTAGE)
-    assert(cacheUsagePercentageActual == (opaAuthorizer.getCache.size() / defaultCacheCapacity.toDouble))
+    assert(cacheUsagePercentageActual == (opaAuthorizer.getCache.estimatedSize() / defaultCacheCapacity.toDouble))
   }
 
 


### PR DESCRIPTION
Hi! Looks like you use Guava only for caching. Did you consider to migrate from Guava to Caffeine?
Caffeine advantages:
- Caffeine has managed to optimize cache-related latency, equivalent throughput to Guava - https://stackoverflow.com/a/55501343
- Guava maintainers recommend using Caffeine, which is better updated and supported.
	Examples of comments from guava maintainers on this matter:
	- https://github.com/google/guava/issues/3700#issuecomment-553998148
	- https://github.com/google/guava/issues/3972#issuecomment-662999556
	- https://github.com/google/guava/issues/3667#issuecomment-546069244
	More examples - https://github.com/newrelic/newrelic-java-agent/issues/258#issue-847353880
- From the point of view of software architecture and security, it is preferable to use highly specialized libraries (Caffeine), 
compared to a large set of common utils that cover a large set of developer needs (Guava)

More other it's reduce Opa-Kafka-Plugin fat-jar size from 2.9MB to 917Kb